### PR TITLE
Make machine manipulation REST-like

### DIFF
--- a/mesito/app.py
+++ b/mesito/app.py
@@ -23,12 +23,22 @@ def _v1_api_blueprint(
     blueprint = flask.Blueprint(name='api_v1', import_name=__name__)
 
     blueprint.route(
-        '/put_machine', methods=['POST'], endpoint='put_machine')(
-            lambda: mesito.route.put_machine(session_factory=session_factory))
+        '/machines', methods=['POST'], endpoint='post_machine')(
+            lambda: mesito.route.post_machine(session_factory=session_factory))
 
     blueprint.route(
-        '/machines', methods=['POST'], endpoint='machines'
-    )(lambda: mesito.route.serve_machines(session_factory=session_factory))
+        '/machines/<int:id>', methods=['PATCH'], endpoint='patch_machine')(
+            lambda id: mesito.route.patch_machine(
+                session_factory=session_factory, id=id))
+
+    blueprint.route(
+        '/machines/<int:id>', methods=['DELETE'], endpoint='delete_machine')(
+            lambda id: mesito.route.delete_machine(
+                session_factory=session_factory, id=id))
+
+    blueprint.route(
+        '/machines', methods=['GET'], endpoint='get_machines')(
+            lambda: mesito.route.get_machines(session_factory=session_factory))
 
     blueprint.route(
         '/put_machine_state', methods=['POST'], endpoint='put_machine_state'

--- a/mesito/front/out.py
+++ b/mesito/front/out.py
@@ -3,6 +3,8 @@ from typing_extensions import TypedDict
 
 from icontract._decorators import require
 
+import mesito.front.valid
+
 # This is necessary since `id` is a built-in.
 # pylint: disable=invalid-name,redefined-builtin,comparison-with-callable
 
@@ -32,7 +34,7 @@ def machine(id: int, name: str, version: int) -> Machine:
 
 class MachinePutEmit(TypedDict):
     """
-    Represent an event emitted when a machine changed.
+    Represent an event emitted when a machine completely changed.
 
     Produce with :func:`machine_put_emit`
     """
@@ -51,3 +53,55 @@ class MachinePutEmit(TypedDict):
 def machine_put_emit(id: int, name: str, version: int) -> MachinePutEmit:
     """Cast the machine into a put event to be emitted."""
     return {"id": id, "name": name, "version": version}
+
+
+class _MachinePatchEmitMandatory(TypedDict):
+    """Define mandatory fields in an event emitted upon machine patch."""
+
+    id: int
+    version: int
+
+
+class MachinePatchEmit(_MachinePatchEmitMandatory, total=False):
+    """
+    Represent an event emitted upon machine patch.
+
+    Produce with :func:`machine_patch_emit`
+    """
+
+    name: str
+
+
+@require(
+    lambda id: id <= 2**53,
+    "ID exactly serializable in JSON double-precision float")
+@require(
+    lambda version: version <= 2 * 53,
+    "Version exactly serializable in JSON double-precision float")
+def machine_patch_emit(
+        data: mesito.front.valid.MachinePatch, id: int,
+        version: int) -> MachinePatchEmit:
+    """Cast the data into an event to be emitted."""
+    result = {"id": id, "version": version}  # type: MachinePatchEmit
+    if 'name' in data:
+        result['name'] = data['name']
+
+    return result
+
+
+class MachineDeleteEmit(TypedDict):
+    """
+    Represent an event emitted when a machine was deleted.
+
+    Produce with :func:`machine_delete_emit`
+    """
+
+    id: int
+
+
+@require(
+    lambda id: id <= 2**53,
+    "ID exactly serializable in JSON double-precision float")
+def machine_delete_emit(id: int) -> MachineDeleteEmit:
+    """Cast the machine ID into an event to be emitted."""
+    return {"id": id}

--- a/pylint.rc
+++ b/pylint.rc
@@ -1,5 +1,5 @@
 [BASIC]
-good-names=i
+good-names=i,id
 
 [TYPECHECK]
 ignored-modules = numpy,cv2

--- a/tests/component_test_mesito.py
+++ b/tests/component_test_mesito.py
@@ -66,20 +66,22 @@ def main() -> None:
 
         logging.info('Adding machines...')
         resp = requests.post(
-            'http://localhost:{}/api/v1/put_machine'.format(port),
+            'http://localhost:{}/api/v1/machines'.format(port),
             json={
                 'name': 'Some Machine'
             }).json()
-        machine_id = resp['id']
+        assert isinstance(resp, int)
+        machine_id = resp
 
         logging.info('Added a machine with the ID: %d', machine_id)
 
         resp = requests.post(
-            'http://localhost:{}/api/v1/put_machine'.format(port),
+            'http://localhost:{}/api/v1/machines'.format(port),
             json={
                 'name': 'Another Machine'
             }).json()
-        machine_id = resp['id']
+        assert isinstance(resp, int)
+        machine_id = resp
 
         logging.info('Added a machine with the ID: %d', machine_id)
 


### PR DESCRIPTION
This commit redefines the API such that the machines can be accessed in
a REST-like manner.